### PR TITLE
Elasticsearch: start service automatically.

### DIFF
--- a/scripts/elasticsearch.sh
+++ b/scripts/elasticsearch.sh
@@ -17,3 +17,6 @@ sudo sed -i "s/# index.number_of_shards: 1/index.number_of_shards: 1/" /etc/elas
 sudo sed -i "s/# index.number_of_replicas: 0/index.number_of_replicas: 0/" /etc/elasticsearch/elasticsearch.yml
 sudo sed -i "s/# bootstrap.mlockall: true/bootstrap.mlockall: true/" /etc/elasticsearch/elasticsearch.yml
 sudo service elasticsearch restart
+
+# Configure to start up Elasticsearch automatically
+sudo update-rc.d elasticsearch defaults 95 10


### PR DESCRIPTION
Also see: https://github.com/fideloper/Vaprobash/pull/290

Note: there was no develop branch, so I did a PR to master.

---

The Elasticsearch service is only started when provisioning. When provisioning
is skipped (after a halt and then up), Elasticsearch would not be running.

As described in the Elasticsearch documentation we can start the service
automatically: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/setup-service.html#_debian_ubuntu
