### PR TITLE
Fixes the grep for the 'latest' nodejs version

### DIFF
--- a/scripts/nodejs.sh
+++ b/scripts/nodejs.sh
@@ -46,7 +46,7 @@ if [[ $NODE_IS_INSTALLED -ne 0 ]]; then
 
     # If set to latest, get the current node version from the home page
     if [[ $NODEJS_VERSION -eq "latest" ]]; then
-        NODEJS_VERSION=`curl 'nodejs.org' | grep 'Current Version' | awk '{ print $3 }' | awk -F\< '{ print $1 }'`
+        NODEJS_VERSION=`curl 'nodejs.org' | grep 'Current Version' | awk '{ print $4 }' | awk -F\< '{ print $1 }'`
     fi
 
     # Install Node


### PR DESCRIPTION
Fixes https://github.com/fideloper/vaprobash12/issues/3 which caused nodejs and packages to be skipped during provisioning. 
