### PR TITLE
Fix couchbase extension version

### DIFF
--- a/scripts/couchbase.sh
+++ b/scripts/couchbase.sh
@@ -36,7 +36,7 @@ if [ ${PHP_IS_INSTALLED} -eq 0 ]; then
     sudo apt-get update
     sudo apt-get -y install libcouchbase2-libevent libcouchbase-dev
 
-    sudo pecl install couchbase
+    sudo pecl install couchbase-1.2.2
     sudo cat > /etc/php5/mods-available/couchbase.ini << EOF
 ; configuration for php couchbase module
 ; priority=30


### PR DESCRIPTION
Due to the issue with Couchbase 2.0 SDK and Xdebug (http://www.couchbase.com/issues/browse/PCBC-294) we need to force pecl to install version 1.2.2 of the Couchbase extension.
